### PR TITLE
Support stable rust

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --no-default-features
 
   test:
     name: Test Suite

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -1,0 +1,33 @@
+on: [push, pull_request]
+
+name: Continuous integration - Stable
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,8 @@ description = "Iterator of fixed length"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["nightly_features"]
+nightly_features = []
+
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # iter_fixed
 
+![crates.io](https://img.shields.io/crates/v/iter_fixed.svg)
+![docs.rs](https://docs.rs/iter_fixed/badge.svg)
+
 *This project is inspired by @leonardo-m 's idea https://github.com/rust-lang/rust/issues/80094#issuecomment-749260428*
 
 **This code is currently very experimental and by default requires a nightly compiler

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 *This project is inspired by @leonardo-m 's idea https://github.com/rust-lang/rust/issues/80094#issuecomment-749260428*
 
-**This code is currently very experimental and requires several unstable
-features and thus requires a nightly compiler**. Type names, function names,
-trait bounds etc. are all very much subject to change.
+**This code is currently very experimental and by default requires a nightly compiler
+in order to work with *the least amount of unsafe code**. Type names, function names,
+trait bounds etc. are all very much subject to change. 
+
+**Please be aware that the `impl FromIteratorFixed for [T; N]` in particular contains lots of
+unsafe code when compiled by a stable compiler without `nightly_features`*
 
 Provides a type and traits for turning collections of fixed size, like arrays,
 into `IteratorFixed` which can be used a bit like an ordinary `Iterator` but
@@ -14,19 +17,27 @@ run time.
 
 Just like `Iterator`, `IteratorFixed` provides methods like:
 
+###### Works on stable rust
 * `map`
 * `inspect`
-* `skip`
-* `step_by`
-* `chain`
 * `enumerate`
-* `take`
 * `zip`
 * `rev`
 * `copied`
 * `cloned`
 
-however it does not support methods like `filter` or `take_while` which will affect the length during runtime.
+###### Requires nightly compiler
+* `skip`
+* `step_by`
+* `chain`
+* `take`
+* `flatten`
+
+however it does not and will never be able to support methods like `filter` or `take_while` which will affect the length during runtime.
+
+## no_std
+
+This crate should work without the full standard library
 
 # Examples
 

--- a/examples/matrix.rs
+++ b/examples/matrix.rs
@@ -1,7 +1,3 @@
-#![allow(incomplete_features)]
-#![feature(const_generics)]
-#![feature(const_evaluatable_checked)]
-
 extern crate iter_fixed;
 
 use iter_fixed::IntoIteratorFixed;

--- a/examples/vector.rs
+++ b/examples/vector.rs
@@ -1,7 +1,3 @@
-#![allow(incomplete_features)]
-#![feature(const_generics)]
-#![feature(const_evaluatable_checked)]
-
 extern crate iter_fixed;
 
 use iter_fixed::IntoIteratorFixed;

--- a/src/from.rs
+++ b/src/from.rs
@@ -61,6 +61,77 @@ impl<I: Iterator, const N: usize> FromIteratorFixed<I, N> for [<I as Iterator>::
         let IteratorFixed { inner: mut it } = iter_fixed;
         // We know that it will yield N elements due to it originating from an IteratorFixed
         // of size N
-        [(); N].map(|_| it.next().unwrap())
+        #[cfg(feature = "nightly_features")]
+        {
+            [(); N].map(|_| it.next().unwrap())
+        }
+
+        // Taken from collect_into_array in rust/library/core/src/array/mod.rs and manually
+        // inlined calls to some not yet stablized functions / changed the code to use stable
+        // alternatives.
+        #[cfg(not(feature = "nightly_features"))]
+        {
+            use core::{mem, mem::MaybeUninit, ptr};
+
+            fn collect_into_array<I, const N: usize>(iter: &mut I) -> Option<[I::Item; N]>
+            where
+                I: Iterator,
+            {
+                if N == 0 {
+                    // SAFETY: An empty array is always inhabited and has no validity invariants.
+                    return unsafe { Some(mem::zeroed()) };
+                }
+
+                struct Guard<T, const N: usize> {
+                    ptr: *mut T,
+                    initialized: usize,
+                }
+
+                impl<T, const N: usize> Drop for Guard<T, N> {
+                    fn drop(&mut self) {
+                        debug_assert!(self.initialized <= N);
+
+                        let initialized_part =
+                            ptr::slice_from_raw_parts_mut(self.ptr, self.initialized);
+
+                        // SAFETY: this raw slice will contain only initialized objects.
+                        unsafe {
+                            ptr::drop_in_place(initialized_part);
+                        }
+                    }
+                }
+                // SAFETY: An uninitialized `[MaybeUninit<_>; N]` is valid.
+                let mut array =
+                    unsafe { MaybeUninit::<[MaybeUninit<_>; N]>::uninit().assume_init() };
+                let mut guard: Guard<_, N> = Guard {
+                    ptr: array.as_mut_ptr() as *mut _,
+                    initialized: 0,
+                };
+
+                while let Some(item) = iter.next() {
+                    // SAFETY: `guard.initialized` starts at 0, is increased by one in the
+                    // loop and the loop is aborted once it reaches N (which is
+                    // `array.len()`).
+                    array[guard.initialized] = MaybeUninit::new(item);
+                    guard.initialized += 1;
+
+                    // Check if the whole array was initialized.
+                    if guard.initialized == N {
+                        mem::forget(guard);
+
+                        // SAFETY: the condition above asserts that all elements are
+                        // initialized and there fore transmuting should be fine
+                        let out: [<I as Iterator>::Item; N] =
+                            unsafe { mem::transmute_copy(&array) };
+                        return Some(out);
+                    }
+                }
+                None
+            }
+
+            // We know that it contains N elements due to originating from IteratorFixed
+            // so this should not panic
+            collect_into_array(&mut it).unwrap()
+        }
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "nightly_features")]
 pub const fn min(a: usize, b: usize) -> usize {
     if a < b {
         a
@@ -6,6 +7,7 @@ pub const fn min(a: usize, b: usize) -> usize {
     }
 }
 
+#[cfg(feature = "nightly_features")]
 pub const fn sub_or_zero(a: usize, b: usize) -> usize {
     if a > b {
         a - b
@@ -14,6 +16,7 @@ pub const fn sub_or_zero(a: usize, b: usize) -> usize {
     }
 }
 
+#[cfg(feature = "nightly_features")]
 pub const fn ceiling_div(x: usize, d: usize) -> usize {
     x / d + (x % d != 0) as usize
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
-#![allow(incomplete_features)]
-#![feature(const_generics)]
-#![feature(const_evaluatable_checked)]
-#![feature(array_map)]
+#![cfg_attr(feature = "nightly_features", allow(incomplete_features))]
+#![cfg_attr(
+    feature = "nightly_features",
+    feature(array_map, const_generics, const_evaluatable_checked)
+)]
 
 use core::iter;
 
@@ -10,8 +11,10 @@ mod from;
 mod helpers;
 mod into;
 
-pub use from::FromIteratorFixed;
+#[cfg(feature = "nightly_features")]
 use helpers::{ceiling_div, min, sub_or_zero};
+
+pub use from::FromIteratorFixed;
 pub use into::IntoIteratorFixed;
 
 /// Iterator of fixed size
@@ -75,6 +78,7 @@ where
 
     // TODO: what should happen when SKIP > N?
     /// See [`core::iter::Iterator::skip`]
+    #[cfg(feature = "nightly_features")]
     pub fn skip<const SKIP: usize>(self) -> IteratorFixed<iter::Skip<I>, { sub_or_zero(N, SKIP) }> {
         IteratorFixed {
             inner: self.inner.skip(SKIP),
@@ -82,6 +86,7 @@ where
     }
 
     /// See [`core::iter::Iterator::step_by`]
+    #[cfg(feature = "nightly_features")]
     pub fn step_by<const STEP: usize>(
         self,
     ) -> IteratorFixed<iter::StepBy<I>, { ceiling_div(N, STEP) }> {
@@ -91,6 +96,7 @@ where
     }
 
     /// See [`core::iter::Iterator::chain`]
+    #[cfg(feature = "nightly_features")]
     pub fn chain<IIF, I2, const M: usize>(
         self,
         other: IIF,
@@ -112,6 +118,7 @@ where
     }
 
     /// See [`core::iter::Iterator::take`]
+    #[cfg(feature = "nightly_features")]
     pub fn take<const TAKE: usize>(self) -> IteratorFixed<iter::Take<I>, { min(TAKE, N) }> {
         IteratorFixed {
             inner: self.inner.take(TAKE),
@@ -198,6 +205,7 @@ where
 {
     // TODO: Would it be better to have `I: Iterator<Item = IntoIteratorFixed`?
     /// See [`core::iter::Iterator::flatten`]
+    #[cfg(feature = "nightly_features")]
     pub fn flatten(self) -> IteratorFixed<iter::Flatten<I>, { M * N }> {
         IteratorFixed {
             inner: self.inner.flatten(),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,5 @@
-#![allow(incomplete_features)]
-#![feature(const_generics)]
+#![cfg_attr(feature = "nightly_features", allow(incomplete_features))]
+#![cfg_attr(feature = "nightly_features", feature(const_generics))]
 
 extern crate iter_fixed;
 
@@ -7,15 +7,13 @@ use iter_fixed::IntoIteratorFixed;
 
 #[test]
 fn test() {
-    let res: [_; 2] = [1u32, 2, 3, 4]
+    let res: [_; 4] = [1u32, 2, 3, 4]
         .into_iter_fixed()
         .zip([4u32, 3, 2, 1])
         .map(|(a, b)| a + b)
-        .skip::<1>()
-        .take::<2>()
         .collect();
 
-    assert_eq!(res, [5, 5]);
+    assert_eq!(res, [5, 5, 5, 5]);
 
     let foo: [(_, _); 3] = [1, 2, 3]
         .into_iter_fixed()
@@ -24,6 +22,7 @@ fn test() {
     assert_eq!(foo, [(1, 42), (2, 42), (3, 42)]);
 }
 
+#[cfg(feature = "nightly_features")]
 #[test]
 fn test_changing_length() {
     let res: [_; 3] = [1, 2, 3, 4].into_iter_fixed().skip::<1>().collect();


### PR DESCRIPTION
Put the methods that require a nightly compiler behind a feature flag `nightly_features`. This makes a subset of the crate work on stable rust.

Add badges