### PR TITLE
Associated types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iter_fixed"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Albin Hedman <albin9604@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [![crates.io](https://img.shields.io/crates/v/iter_fixed.svg)](https://crates.io/crates/iter_fixed)
 [![docs.rs](https://docs.rs/iter_fixed/badge.svg)](https://docs.rs/iter_fixed/)
 
+![Stable](https://github.com/usbalbin/iter_fixed/actions/workflows/stable.yml/badge.svg)
+![Nightly](https://github.com/usbalbin/iter_fixed/actions/workflows/nightly.yml/badge.svg)
+![Miri](https://github.com/usbalbin/iter_fixed/actions/workflows/miri.yml/badge.svg)
+
 *This project is inspired by @leonardo-m 's idea https://github.com/rust-lang/rust/issues/80094#issuecomment-749260428*
 
 **This code is currently very experimental and by default requires a nightly compiler

--- a/src/into.rs
+++ b/src/into.rs
@@ -15,7 +15,7 @@ pub unsafe trait IntoIteratorFixed<const N: usize> {
     /// The type of the elements being iterated over.
     type Item;
 
-    /// What will be the underlaying iterator for the IteratorFixed that we turning this into?
+    /// What will be the underlaying iterator for the IteratorFixed that we are turning this into?
     type IntoIter: Iterator<Item = Self::Item>;
 
     /// Creates a fixed size iterator from a value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,31 @@ where
         }
     }
 
+    #[cfg(feature = "nightly_features")]
+    pub fn flatten<IIF, const M: usize>(self) -> IteratorFixed<iter::Flatten<I>, { M * N }>
+    where
+        I: Iterator<Item = IIF>,
+        IIF: IntoIteratorFixed<M> + IntoIterator,
+    {
+        IteratorFixed {
+            inner: self.inner.flatten(),
+        }
+    }
+
+    #[cfg(feature = "nightly_features")]
+    pub fn flat_map<F, IIF, const M: usize>(
+        self,
+        f: F,
+    ) -> IteratorFixed<iter::FlatMap<I, IIF, F>, { M * N }>
+    where
+        F: FnMut(I::Item) -> IIF,
+        IIF: IntoIteratorFixed<M> + IntoIterator,
+    {
+        IteratorFixed {
+            inner: self.inner.flat_map(f),
+        }
+    }
+
     /// Transforms a fixed size iterator into a collection of compile time known size.
     ///
     /// Basic usage:
@@ -194,29 +219,6 @@ where
             inner: self.inner.cloned(),
         }
     }
-}
-
-impl<I, IIF, const N: usize, const M: usize> IteratorFixed<I, N>
-where
-    I: Iterator<Item = IIF>,
-    IIF: IntoIteratorFixed<M> + IntoIterator,
-{
-    #[cfg(feature = "nightly_features")]
-    pub fn flatten(self) -> IteratorFixed<iter::Flatten<I>, { M * N }> {
-        IteratorFixed {
-            inner: self.inner.flatten(),
-        }
-    }
-
-    /*
-    pub fn flat_map(self, f: F) -> FlatMap<Self, U, F>
-    where
-        F: FnMut(Self::Item) -> U,
-        U: IntoIterator,
-    {
-        unimplemented!()
-    }
-    */
 }
 
 /// Convert the fixed size iterator into an ordinary [`core::iter::Iterator`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,13 +196,11 @@ where
     }
 }
 
-impl<I, I2, const N: usize, const M: usize> IteratorFixed<I, N>
+impl<I, IIF, const N: usize, const M: usize> IteratorFixed<I, N>
 where
-    I: Iterator<Item = IteratorFixed<I2, M>>,
-    I2: Iterator,
+    I: Iterator<Item = IIF>,
+    IIF: IntoIteratorFixed<M> + IntoIterator,
 {
-    // TODO: Would it be better to have `I: Iterator<Item = IntoIteratorFixed`?
-    /// See [`core::iter::Iterator::flatten`]
     #[cfg(feature = "nightly_features")]
     pub fn flatten(self) -> IteratorFixed<iter::Flatten<I>, { M * N }> {
         IteratorFixed {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,13 +97,12 @@ where
 
     /// See [`core::iter::Iterator::chain`]
     #[cfg(feature = "nightly_features")]
-    pub fn chain<IIF, I2, const M: usize>(
+    pub fn chain<IIF, const M: usize>(
         self,
         other: IIF,
-    ) -> IteratorFixed<iter::Chain<I, I2>, { N + M }>
+    ) -> IteratorFixed<iter::Chain<I, IIF::IntoIter>, { N + M }>
     where
-        IIF: IntoIteratorFixed<I2, M>,
-        I2: Iterator<Item = <I as IntoIterator>::Item>,
+        IIF: IntoIteratorFixed<M, Item = I::Item>,
     {
         IteratorFixed {
             inner: self.inner.chain(other.into_iter_fixed().inner),
@@ -126,10 +125,9 @@ where
     }
 
     /// See [`core::iter::Iterator::zip`]
-    pub fn zip<U, IIF, I2>(self, other: IIF) -> IteratorFixed<iter::Zip<I, I2>, N>
+    pub fn zip<IIF>(self, other: IIF) -> IteratorFixed<iter::Zip<I, IIF::IntoIter>, N>
     where
-        IIF: IntoIteratorFixed<I2, N>,
-        I2: Iterator<Item = U>,
+        IIF: IntoIteratorFixed<N>,
     {
         IteratorFixed {
             inner: self.inner.zip(other.into_iter_fixed().inner),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ where
     pub fn map<U, F: FnMut(<I as Iterator>::Item) -> U>(
         self,
         p: F,
-    ) -> IteratorFixed<iter::Map<I, F>, N> {
+    ) -> IteratorFixed<impl Iterator<Item = U>, N> {
         IteratorFixed {
             inner: self.inner.map(p),
         }
@@ -70,7 +70,7 @@ where
     pub fn inspect<F: FnMut(&<I as Iterator>::Item)>(
         self,
         p: F,
-    ) -> IteratorFixed<iter::Inspect<I, F>, N> {
+    ) -> IteratorFixed<impl Iterator<Item = I::Item>, N> {
         IteratorFixed {
             inner: self.inner.inspect(p),
         }
@@ -79,7 +79,9 @@ where
     // TODO: what should happen when SKIP > N?
     /// See [`core::iter::Iterator::skip`]
     #[cfg(feature = "nightly_features")]
-    pub fn skip<const SKIP: usize>(self) -> IteratorFixed<iter::Skip<I>, { sub_or_zero(N, SKIP) }> {
+    pub fn skip<const SKIP: usize>(
+        self,
+    ) -> IteratorFixed<impl Iterator<Item = I::Item>, { sub_or_zero(N, SKIP) }> {
         IteratorFixed {
             inner: self.inner.skip(SKIP),
         }
@@ -89,7 +91,7 @@ where
     #[cfg(feature = "nightly_features")]
     pub fn step_by<const STEP: usize>(
         self,
-    ) -> IteratorFixed<iter::StepBy<I>, { ceiling_div(N, STEP) }> {
+    ) -> IteratorFixed<impl Iterator<Item = I::Item>, { ceiling_div(N, STEP) }> {
         IteratorFixed {
             inner: self.inner.step_by(STEP),
         }
@@ -100,7 +102,7 @@ where
     pub fn chain<IIF, const M: usize>(
         self,
         other: IIF,
-    ) -> IteratorFixed<iter::Chain<I, IIF::IntoIter>, { N + M }>
+    ) -> IteratorFixed<impl Iterator<Item = I::Item>, { N + M }>
     where
         IIF: IntoIteratorFixed<M, Item = I::Item>,
     {
@@ -110,7 +112,7 @@ where
     }
 
     /// See [`core::iter::Iterator::enumerate`]
-    pub fn enumerate(self) -> IteratorFixed<iter::Enumerate<I>, N> {
+    pub fn enumerate(self) -> IteratorFixed<impl Iterator<Item = (usize, I::Item)>, N> {
         IteratorFixed {
             inner: self.inner.enumerate(),
         }
@@ -118,14 +120,19 @@ where
 
     /// See [`core::iter::Iterator::take`]
     #[cfg(feature = "nightly_features")]
-    pub fn take<const TAKE: usize>(self) -> IteratorFixed<iter::Take<I>, { min(TAKE, N) }> {
+    pub fn take<const TAKE: usize>(
+        self,
+    ) -> IteratorFixed<impl Iterator<Item = I::Item>, { min(TAKE, N) }> {
         IteratorFixed {
             inner: self.inner.take(TAKE),
         }
     }
 
     /// See [`core::iter::Iterator::zip`]
-    pub fn zip<IIF>(self, other: IIF) -> IteratorFixed<iter::Zip<I, IIF::IntoIter>, N>
+    pub fn zip<IIF>(
+        self,
+        other: IIF,
+    ) -> IteratorFixed<impl Iterator<Item = (I::Item, IIF::Item)>, N>
     where
         IIF: IntoIteratorFixed<N>,
     {
@@ -146,7 +153,7 @@ where
     */
 
     /// See [`core::iter::Iterator::rev`]
-    pub fn rev(self) -> IteratorFixed<iter::Rev<I>, N>
+    pub fn rev(self) -> IteratorFixed<impl Iterator<Item = I::Item>, N>
     where
         I: iter::DoubleEndedIterator,
     {
@@ -209,7 +216,7 @@ where
     I: Iterator<Item = &'a T>,
 {
     /// See [`core::iter::Iterator::copied`]
-    pub fn copied(self) -> IteratorFixed<iter::Copied<I>, N>
+    pub fn copied(self) -> IteratorFixed<impl Iterator<Item = T>, N>
     where
         T: Copy,
     {
@@ -219,7 +226,7 @@ where
     }
 
     /// See [`core::iter::Iterator::cloned`]
-    pub fn cloned(self) -> IteratorFixed<iter::Cloned<I>, N>
+    pub fn cloned(self) -> IteratorFixed<impl Iterator<Item = T>, N>
     where
         T: Clone,
     {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -55,7 +55,7 @@ fn test_changing_length() {
 
     assert_eq!(res, [1, 2]);
 
-    // TODO: Remove call to _.into_iter_fixed() once no longer needed
+    // TODO: Remove call to _.into_iter_fixed() [T; N] implements IntoIterator, see https://github.com/rust-lang/rust/pull/84147
     let res: [_; 4] = [[1, 2].into_iter_fixed(), [3, 4].into_iter_fixed()]
         .into_iter_fixed()
         .flatten()
@@ -63,7 +63,7 @@ fn test_changing_length() {
 
     assert_eq!(res, [1, 2, 3, 4]);
 
-    // TODO: Remove call to _.into_iter_fixed() once no longer needed
+    // TODO: Remove call to _.into_iter_fixed() [T; N] implements IntoIterator, see https://github.com/rust-lang/rust/pull/84147
     let res: [_; 6] = [1, 2, 3]
         .into_iter_fixed()
         .flat_map(|x| [x, x].into_iter_fixed())

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -55,18 +55,17 @@ fn test_changing_length() {
 
     assert_eq!(res, [1, 2]);
 
-    // TODO: Remove call to _.into_iter_fixed() [T; N] implements IntoIterator, see https://github.com/rust-lang/rust/pull/84147
-    let res: [_; 4] = [[1, 2].into_iter_fixed(), [3, 4].into_iter_fixed()]
-        .into_iter_fixed()
-        .flatten()
-        .collect();
+    let res: [_; 4] = [[1, 2], [3, 4]].into_iter_fixed().flatten().collect();
 
     assert_eq!(res, [1, 2, 3, 4]);
 
-    // TODO: Remove call to _.into_iter_fixed() [T; N] implements IntoIterator, see https://github.com/rust-lang/rust/pull/84147
+    let res: [_; 6] = [1, 2, 3].into_iter_fixed().flat_map(|x| [x, x]).collect();
+
+    assert_eq!(res, [1, 1, 2, 2, 3, 3]);
+
     let res: [_; 6] = [1, 2, 3]
         .into_iter_fixed()
-        .flat_map(|x| [x, x].into_iter_fixed())
+        .flat_map(|x| IntoIteratorFixed::<2>::into_iter_fixed(core::iter::repeat(x)))
         .collect();
 
     assert_eq!(res, [1, 1, 2, 2, 3, 3]);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -55,11 +55,19 @@ fn test_changing_length() {
 
     assert_eq!(res, [1, 2]);
 
-    // Remove call to _.into_iter_fixed() once no longer needed
+    // TODO: Remove call to _.into_iter_fixed() once no longer needed
     let res: [_; 4] = [[1, 2].into_iter_fixed(), [3, 4].into_iter_fixed()]
         .into_iter_fixed()
         .flatten()
         .collect();
 
     assert_eq!(res, [1, 2, 3, 4]);
+
+    // TODO: Remove call to _.into_iter_fixed() once no longer needed
+    let res: [_; 6] = [1, 2, 3]
+        .into_iter_fixed()
+        .flat_map(|x| [x, x].into_iter_fixed())
+        .collect();
+
+    assert_eq!(res, [1, 1, 2, 2, 3, 3]);
 }


### PR DESCRIPTION
* Moved from generic type paramater `I` to associated type `IntoIter` and added associated type `Item` to be closer to std::iter::IntoIterator Iterator. (breaking)
* Relaxed `flatten` to accept IntoIteratorFixed instead of requiring IteratorFixed as item in the outer iterator.
* Implemented `flat_map`
* Hide return types
* Add CI badges