### PR TITLE
Added IteratorFixed::from_fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iter_fixed"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Albin Hedman <albin9604@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,34 @@ impl<I, const N: usize> IteratorFixed<I, N>
 where
     I: Iterator,
 {
+    /// Creates a new iterator of fixed size where each iteration calls the provided closure F: FnMut(usize) -> T
+    ///
+    /// This allows very simple initialization of types that implement `FromIteratorFixed` such as arrays.
+    ///
+    /// Note: This function is quite similar to [`iter::from_fn`] however note that in contrast to `iter::from_fn`, 
+    /// in `IteratorFixed::from_fn` the provided function does not have any say in the number of elements.
+    /// The length is entirely determined by `N`.
+    ///
+    /// Basic usage:
+    /// ```
+    /// use iter_fixed::IteratorFixed;
+    ///
+    /// let zero_two_four: [i32; 3] = IteratorFixed::from_fn(|i| 2 * i).collect();
+    ///
+    /// assert_eq!(a, [0, 2, 4]);
+    /// ```
+    pub fn from_fn<'a, F, T: 'a>(
+        mut f: F,
+    ) -> IteratorFixed<impl Iterator<Item = T> + 'a, N>
+    where
+        F: FnMut(usize) -> T + 'a,
+    {
+        [(); N]
+            .into_iter_fixed()
+            .enumerate()
+            .map(move |(i, _)| f(i))
+    }
+
     /// # Safety
     /// Caller has to guarantee that the given iterator will yield exactly N elements
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,38 +43,36 @@ pub struct IteratorFixed<I: Iterator, const N: usize> {
     inner: I,
 }
 
+/// Creates a new iterator of fixed size where each iteration calls the provided closure F: FnMut(usize) -> T
+///
+/// This allows very simple initialization of types that implement `FromIteratorFixed` such as arrays.
+///
+/// Note: This function is quite similar to [`iter::from_fn`] however note that in contrast to `iter::from_fn`,
+/// in `IteratorFixed::from_fn` the provided function does not have any say in the number of elements.
+/// The length is entirely determined by `N`.
+///
+/// Basic usage:
+/// ```
+/// let zero_two_four: [usize; 3] = iter_fixed::from_fn(|i| 2 * i).collect();
+///
+/// assert_eq!(zero_two_four, [0, 2, 4]);
+/// ```
+pub fn from_fn<'a, F, T: 'a, const N: usize>(
+    mut f: F,
+) -> IteratorFixed<impl Iterator<Item = T> + 'a, N>
+where
+    F: FnMut(usize) -> T + 'a,
+{
+    [(); N]
+        .into_iter_fixed()
+        .enumerate()
+        .map(move |(i, _)| f(i))
+}
+
 impl<I, const N: usize> IteratorFixed<I, N>
 where
     I: Iterator,
 {
-    /// Creates a new iterator of fixed size where each iteration calls the provided closure F: FnMut(usize) -> T
-    ///
-    /// This allows very simple initialization of types that implement `FromIteratorFixed` such as arrays.
-    ///
-    /// Note: This function is quite similar to [`iter::from_fn`] however note that in contrast to `iter::from_fn`, 
-    /// in `IteratorFixed::from_fn` the provided function does not have any say in the number of elements.
-    /// The length is entirely determined by `N`.
-    ///
-    /// Basic usage:
-    /// ```
-    /// use iter_fixed::IteratorFixed;
-    ///
-    /// let zero_two_four: [i32; 3] = IteratorFixed::from_fn(|i| 2 * i).collect();
-    ///
-    /// assert_eq!(a, [0, 2, 4]);
-    /// ```
-    pub fn from_fn<'a, F, T: 'a>(
-        mut f: F,
-    ) -> IteratorFixed<impl Iterator<Item = T> + 'a, N>
-    where
-        F: FnMut(usize) -> T + 'a,
-    {
-        [(); N]
-            .into_iter_fixed()
-            .enumerate()
-            .map(move |(i, _)| f(i))
-    }
-
     /// # Safety
     /// Caller has to guarantee that the given iterator will yield exactly N elements
     ///


### PR DESCRIPTION
Adds `IteratorFixed::from_fn` which enables initialization of arrays similar to [array-init](https://crates.io/crates/array-init). `IteratorFixed::from_fn` can also be used to initialize other types that implement `FromIteratorFixed`

```rust
let zero_two_four: [i32; 3] = iter_fixed::from_fn(|i| 2 * i).collect();

assert_eq!(zero_two_four, [0, 2, 4]);
```