### PR TITLE
fix: nightly flags and clippy warnings

### DIFF
--- a/src/into.rs
+++ b/src/into.rs
@@ -73,7 +73,7 @@ unsafe impl<T, const N: usize> IntoIteratorFixed<N> for [T; N] {
     /// ```
     fn into_iter_fixed(self) -> IteratorFixed<array::IntoIter<T, N>, N> {
         // Safety: array::IntoIter::new([T; N]) always yields N elements
-        unsafe { IteratorFixed::from_iter(array::IntoIter::new(self)) }
+        unsafe { IteratorFixed::from_iter(<[T; N] as IntoIterator>::into_iter(self)) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,7 @@
 #![no_std]
 #![allow(stable_features)]
 #![cfg_attr(feature = "nightly_features", allow(incomplete_features))]
-#![cfg_attr(
-    feature = "nightly_features",
-    feature(const_generics, const_evaluatable_checked)
-)]
+#![cfg_attr(feature = "nightly_features", feature(generic_const_exprs))]
 
 use core::iter;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "nightly_features", allow(incomplete_features))]
-#![cfg_attr(feature = "nightly_features", feature(const_generics))]
+#![cfg_attr(feature = "nightly_features", feature(generic_const_exprs))]
 
 extern crate iter_fixed;
 
@@ -15,11 +15,11 @@ fn test() {
 
     assert_eq!(res, [5, 5, 5, 5]);
 
-    let foo: [(_, _); 3] = [1, 2, 3]
+    let res: [(_, _); 3] = [1, 2, 3]
         .into_iter_fixed()
         .zip(core::iter::repeat(42))
         .collect();
-    assert_eq!(foo, [(1, 42), (2, 42), (3, 42)]);
+    assert_eq!(res, [(1, 42), (2, 42), (3, 42)]);
 }
 
 #[cfg(feature = "nightly_features")]


### PR DESCRIPTION
`IntoIter::new` is deprecated

`generic_const_exprs` is the only required nightly flag

`foo` is a [disallowed name](https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_names)