### PR TITLE
feat(breaking): make `FromIteratorFixed` more generic

### DIFF
--- a/src/from.rs
+++ b/src/from.rs
@@ -10,7 +10,7 @@ use crate::IteratorFixed;
 /// documentation for more examples.
 ///
 /// See also: [`crate::IntoIteratorFixed`].
-pub trait FromIteratorFixed<I: Iterator, const N: usize> {
+pub trait FromIteratorFixed<T, const N: usize> {
     /// Creates a value from a fixed size iterator.
     ///
     /// Basic usage:
@@ -32,10 +32,10 @@ pub trait FromIteratorFixed<I: Iterator, const N: usize> {
     /// let a: [i32; 3] = two_four_six.collect();
     /// assert_eq!(a, [2, 4, 6]);
     /// ```
-    fn from_iter_fixed(iter_fixed: IteratorFixed<I, N>) -> Self;
+    fn from_iter_fixed<I: Iterator<Item = T>>(iter_fixed: IteratorFixed<I, N>) -> Self;
 }
 
-impl<I: Iterator, const N: usize> FromIteratorFixed<I, N> for [<I as Iterator>::Item; N] {
+impl<T, const N: usize> FromIteratorFixed<T, N> for [T; N] {
     /// Creates an array from a fixed size iterator.
     ///
     /// Basic usage:
@@ -57,7 +57,7 @@ impl<I: Iterator, const N: usize> FromIteratorFixed<I, N> for [<I as Iterator>::
     /// let a: [i32; 3] = two_four_six.collect();
     /// assert_eq!(a, [2, 4, 6]);
     /// ```
-    fn from_iter_fixed(iter_fixed: IteratorFixed<I, N>) -> Self {
+    fn from_iter_fixed<I: Iterator<Item = T>>(iter_fixed: IteratorFixed<I, N>) -> Self {
         let IteratorFixed { inner: mut it } = iter_fixed;
         // We know that it will yield N elements due to it originating from an IteratorFixed
         // of size N

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ where
     /// let a: [i32; 3] = two_four_six.collect();
     /// assert_eq!(a, [2, 4, 6]);
     /// ```
-    pub fn collect<U: FromIteratorFixed<I, N>>(self) -> U {
+    pub fn collect<U: FromIteratorFixed<I::Item, N>>(self) -> U {
         U::from_iter_fixed(self)
     }
 }


### PR DESCRIPTION
Presently, it's not really possible to express `FromIteratorFixed` as a generic bound. For example

```rust
fn build_cs<C, const N: usize>(vs: Vec<[u64; N]>) -> Vec<C>
where: C: FromIteratorFixed<WHAT_TO_PUT_HERE, N> {
  vs.into_iter().map(|v| v.into_iter_fixed().map(|i| i+10).collect()).collect()
}
```

This is because the `FromIteratorFixed` currently locks in the iterator type at the trait level, while all the `IteratorFixed` functions like `map` completely hide the type behind `impl Iterator`.

The solution is to move the iterator type down to the `from_iter_fixed` method, only preserving the `Item` type at the trait level. This is also logically correct as the specifics of the iterator type should not restrict implementations of `FromIteratorFixed`.

This is technically a breaking change, but I don't think it's likely to impact any casual users of this crate, only downstream crates which do things like add implementations of `FromIteratorFixed` will have to perform minor updates to signatures.