### PR TITLE
v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iter_fixed"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Albin Hedman <albin9604@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can also take a look at examples : [`matrix.rs`] and [`vector.rs`]
 [`vector.rs`]: source/examples/vector.rs
 
 
-Current version: 0.3.1
+Current version: 0.4.0
 
 ## no_std
 


### PR DESCRIPTION
# v0.4.0

## Breaking
* #21 Update `FromIteratorFixed` trait to avoid unnameable iterator type as type paramater in the trait
  ```diff
  - pub trait FromIteratorFixed<I: Iterator, const N: usize> {
  -     fn from_iter_fixed(iter_fixed: IteratorFixed<I, N>) -> Self;
  + pub trait FromIteratorFixed<T, const N: usize> {
  +     fn from_iter_fixed<I: Iterator<Item = T>>(iter_fixed: IteratorFixed<I, N>) -> Self;
    }
  ```
## Other changes

* #22
* #20
* #24
* #25 

## Thank you
* @Daniel-Aaron-Bloom
* @gwen-lg 