### PR TITLE
Implement more methods on stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ default = []
 nightly_features = []
 
 [dependencies]
+typenum = { version = "1.17.0", features = ["const-generics"] }
+typenum_mappings = "0.1.0"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,22 +1,50 @@
-#[cfg(feature = "nightly_features")]
-pub const fn min(a: usize, b: usize) -> usize {
-    if a < b {
-        a
-    } else {
-        b
+use typenum::{operator_aliases as ty_ops, U};
+
+use crate::IteratorFixed;
+
+/// A trait implemented for all `IterFixed<N>` to allow constructing `IterFixed` when `N` is unnamable.
+pub trait ErasedIterFixed<I> {
+    /// # Safety
+    ///
+    /// The N value of the [`IterFixed`] created must be the same as the number of items in the Iterator.
+    unsafe fn new(iter: I) -> Self;
+}
+
+impl<I: Iterator, const N: usize> ErasedIterFixed<I> for IteratorFixed<I, N> {
+    unsafe fn new(inner: I) -> Self {
+        Self { inner }
     }
 }
 
-#[cfg(feature = "nightly_features")]
-pub const fn sub_or_zero(a: usize, b: usize) -> usize {
-    if a > b {
-        a - b
-    } else {
-        0
-    }
+pub trait TypenumToFixedIter<I: Iterator> {
+    type FixedIter: ErasedIterFixed<I>;
 }
 
-#[cfg(feature = "nightly_features")]
-pub const fn ceiling_div(x: usize, d: usize) -> usize {
-    x / d + (x % d != 0) as usize
-}
+typenum_mappings::impl_typenum_mapping!(
+    impl<const N: usize = 0..=1024, I: Iterator> TypenumToFixedIter<I> for #TypeNumName {
+        type FixedIter = IteratorFixed<I, N>;
+    }
+);
+
+pub(crate) type RunTypeNumToFixedIter<I, T> = <T as TypenumToFixedIter<I>>::FixedIter;
+
+pub(crate) type TyNot<T> = <T as core::ops::Not>::Output;
+type TyCelDiv<X, D> = ty_ops::Sum<
+    // X / D
+    ty_ops::Quot<X, D>,
+    // + !
+    TyNot<
+        ty_ops::Eq<
+            // X % 0
+            ty_ops::Mod<X, D>,
+            // == 0
+            typenum::U0,
+        >,
+    >,
+>;
+
+pub(crate) type RunCelDiv<const X: usize, const D: usize> = TyCelDiv<U<X>, U<D>>;
+pub(crate) type RunAdd<const X: usize, const Y: usize> = ty_ops::Sum<U<X>, U<Y>>;
+pub(crate) type RunSub<const X: usize, const Y: usize> = ty_ops::Diff<U<X>, U<Y>>;
+pub(crate) type RunMul<const X: usize, const Y: usize> = ty_ops::Prod<U<X>, U<Y>>;
+pub(crate) type RunMin<const X: usize, const Y: usize> = ty_ops::Minimum<U<X>, U<Y>>;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -22,7 +22,6 @@ fn test() {
     assert_eq!(res, [(1, 42), (2, 42), (3, 42)]);
 }
 
-#[cfg(feature = "nightly_features")]
 #[test]
 fn test_changing_length() {
     let res: [_; 3] = [1, 2, 3, 4].into_iter_fixed().skip::<1>().collect();
@@ -59,14 +58,17 @@ fn test_changing_length() {
 
     assert_eq!(res, [1, 2, 3, 4]);
 
-    let res: [_; 6] = [1, 2, 3].into_iter_fixed().flat_map(|x| [x, x]).collect();
+    #[cfg(feature = "nightly_features")]
+    {
+        let res: [_; 6] = [1, 2, 3].into_iter_fixed().flat_map(|x| [x, x]).collect();
 
-    assert_eq!(res, [1, 1, 2, 2, 3, 3]);
+        assert_eq!(res, [1, 1, 2, 2, 3, 3]);
 
-    let res: [_; 6] = [1, 2, 3]
-        .into_iter_fixed()
-        .flat_map(|x| IntoIteratorFixed::<2>::into_iter_fixed(core::iter::repeat(x)))
-        .collect();
+        let res: [_; 6] = [1, 2, 3]
+            .into_iter_fixed()
+            .flat_map(|x| IntoIteratorFixed::<2>::into_iter_fixed(core::iter::repeat(x)))
+            .collect();
 
-    assert_eq!(res, [1, 1, 2, 2, 3, 3]);
+        assert_eq!(res, [1, 1, 2, 2, 3, 3]);
+    }
 }


### PR DESCRIPTION
Replaces most of the usage of `generic_const_exprs` with typenum based math.

Pros:
- More methods usable on stable

Cons:
- Higher complexity, as typenum math requires a ton of bounds
- Only supports iterators up to `1024` length, as written in `helpers.rs` as the `typenum_mapping` call.

This method of using typenum to replace GCE was originally developed for https://github.com/GnomedDev/aformat, and seems to work well from the user perspective. 

Sadly, I wasn't able to replace `flat_map`, as one limitation is how I cannot use "return type impl trait" (RTIT) as the type must be named in the `where` bounds and this is necessary whenever closures are involved as they are totally unnameable.